### PR TITLE
シェア検索jbuilder（見送り）

### DIFF
--- a/app/assets/javascripts/old_share_index.js
+++ b/app/assets/javascripts/old_share_index.js
@@ -1,0 +1,56 @@
+// シェア検索でチェックボックスにチェックを入れたイベントを検知し
+// jbuilderにてデータ取得後、js内で生成したHTMLを挿入する。
+// ↓
+// チェックを入れるたびにデータが増えるバグはあるものの動き自体は実装できている。
+// バグの修正は可能そうだが、refileの画像を指定できないため今回は見送り
+
+
+// // $(document).on('turbolinks:load', function() {
+
+// //   $(document).on('click', "#search_status", function(){
+// //     let status;
+// //     if($(this).prop('checked')){
+// //       status = "1";
+// //     }else{
+// //       status = "";
+// //     };
+// //     search_sub(status)
+// //   });
+
+// //   function search_sub(status){
+// //     $.ajax({
+// //       type: 'GET',
+// //       url: '/shares',
+// //       data:{search_status: status},
+// //       dataType: 'json'
+// //     })
+// //     .done(function(data){
+// //       data.forEach(function(data){
+// //         built_html(data);
+// //       });
+// //     });
+// // }
+// //   function built_html(data){
+// //     let html = `
+// //             <div class="share_block ml-3 mr-2 mt-2 mb-2">
+// //               <div class="share_item">
+// //                 <a class="share_link" href="/shares/${data.id}"></a>
+// //                 <div class="text-center share_text">
+// //                   ${data.name}
+// //                 </div>
+// //                 <div class="text-center share_text">
+// //                   ${data.content}
+// //                 </div>
+// //                 <div class="text-center">
+// //                   [${data.category}]
+// //                 </div>
+// //                 <div class="text-center">
+// //                   <p class="fas fa-paperclip"></p>
+// //                   ${data.clips}
+// //                 </div>
+// //               </div>
+// //             </div>
+// //     `;
+// //     $('.built_target').append(html);
+// //   }
+// // });

--- a/app/controllers/old_shares_controller.rb
+++ b/app/controllers/old_shares_controller.rb
@@ -1,0 +1,144 @@
+# // シェア検索でチェックボックスにチェックを入れたイベントを検知し
+# // jbuilderにてデータ取得後、js内で生成したHTMLを挿入する。
+# // ↓
+# // チェックを入れるたびにデータが増えるバグはあるものの動き自体は実装できている。
+# // バグの修正は可能そうだが、refileの画像を指定できないため今回は見送り
+# class SharesController < ApplicationController
+#   before_action :user_info
+
+#   def index
+#     # 検索条件がある場合は絞り込んでいく
+#     @category = params[:search_category]
+#     @word = params[:search_word]
+#     @shares = Share.joins(:goal)
+#     # カテゴリ選択
+#     if params[:search_category].present?
+#       @shares = @shares.where(category_id: params[:search_category])
+#     end
+#     # 達成済みのみ
+#     if params[:search_status].present? && params[:search_status] == "1"
+#       @shares = @shares.merge(Goal.share_status)
+#     end
+#     # 文字の部分一致
+#     if params[:search_word].present?
+#       @shares = @shares.merge(Goal.share_word(params[:search_word]))
+#     end
+#     # クリップ順に並べ替え
+#     if params[:search_sort].present? && params[:search_sort] == "1"
+#       @shares = @shares.left_joins(:clips).group("shares.id").order("count(*) desc")
+#     end
+
+#     respond_to do |format|
+#       format.html
+#       format.json
+#     end
+#   end
+
+#   def show
+#     @share = Share.find(params[:id])
+#     @tasks_week = [
+#       @tasks_sun = Task.where(goal_id: @share.goal_id, sun: "1"),
+#       @tasks_mon = Task.where(goal_id: @share.goal_id, mon: "1"),
+#       @tasks_tue = Task.where(goal_id: @share.goal_id, tue: "1"),
+#       @tasks_wed = Task.where(goal_id: @share.goal_id, wed: "1"),
+#       @tasks_thu = Task.where(goal_id: @share.goal_id, thu: "1"),
+#       @tasks_fri = Task.where(goal_id: @share.goal_id, fri: "1"),
+#       @tasks_sat = Task.where(goal_id: @share.goal_id, sat: "1")
+#     ]
+#   end
+
+#   def new
+#     @share = Share.new
+#     @goal = Goal.find(params[:goal_id])
+#     @tasks_week = [
+#       @tasks_sun = Task.where(goal_id: @goal.id, sun: "1"),
+#       @tasks_mon = Task.where(goal_id: @goal.id, mon: "1"),
+#       @tasks_tue = Task.where(goal_id: @goal.id, tue: "1"),
+#       @tasks_wed = Task.where(goal_id: @goal.id, wed: "1"),
+#       @tasks_thu = Task.where(goal_id: @goal.id, thu: "1"),
+#       @tasks_fri = Task.where(goal_id: @goal.id, fri: "1"),
+#       @tasks_sat = Task.where(goal_id: @goal.id, sat: "1")
+#     ]
+#   end
+
+#   def create
+#     @share = current_user.shares.build(share_params)
+#     @share.goal_id = params[:goal_id]
+#     if @share.save
+#       flash[:notice] = "シェアしました"
+#       redirect_to share_path(@share.id)
+#     else
+#       @goal = Goal.find(params[:goal_id])
+#       @tasks_week = [
+#         @tasks_sun = Task.where(goal_id: @goal.id, sun: "1"),
+#         @tasks_mon = Task.where(goal_id: @goal.id, mon: "1"),
+#         @tasks_tue = Task.where(goal_id: @goal.id, tue: "1"),
+#         @tasks_wed = Task.where(goal_id: @goal.id, wed: "1"),
+#         @tasks_thu = Task.where(goal_id: @goal.id, thu: "1"),
+#         @tasks_fri = Task.where(goal_id: @goal.id, fri: "1"),
+#         @tasks_sat = Task.where(goal_id: @goal.id, sat: "1")
+#       ]
+#       render 'new'
+#     end
+#   end
+
+#   def edit
+#     @share = Share.find(params[:id])
+#     # アクセス権
+#     @correct_user = User.find(@share.goal.user_id)
+#     if @correct_user.id != current_user.id
+#       redirect_to goals_path
+#     end
+#     @tasks_week = [
+#       @tasks_sun = Task.where(goal_id: @share.goal_id, sun: "1"),
+#       @tasks_mon = Task.where(goal_id: @share.goal_id, mon: "1"),
+#       @tasks_tue = Task.where(goal_id: @share.goal_id, tue: "1"),
+#       @tasks_wed = Task.where(goal_id: @share.goal_id, wed: "1"),
+#       @tasks_thu = Task.where(goal_id: @share.goal_id, thu: "1"),
+#       @tasks_fri = Task.where(goal_id: @share.goal_id, fri: "1"),
+#       @tasks_sat = Task.where(goal_id: @share.goal_id, sat: "1")
+#     ]
+#   end
+
+#   def update
+#     @share = Share.find(params[:id])
+#     # アクセス権
+#     @correct_user = User.find(@share.goal.user_id)
+#     if @correct_user.id != current_user.id
+#       redirect_to goals_path
+#     end
+#     @tasks_week = [
+#       @tasks_sun = Task.where(goal_id: @share.goal_id, sun: "1"),
+#       @tasks_mon = Task.where(goal_id: @share.goal_id, mon: "1"),
+#       @tasks_tue = Task.where(goal_id: @share.goal_id, tue: "1"),
+#       @tasks_wed = Task.where(goal_id: @share.goal_id, wed: "1"),
+#       @tasks_thu = Task.where(goal_id: @share.goal_id, thu: "1"),
+#       @tasks_fri = Task.where(goal_id: @share.goal_id, fri: "1"),
+#       @tasks_sat = Task.where(goal_id: @share.goal_id, sat: "1")
+#     ]
+#     if @share.update(share_params)
+#       flash[:notice] = "更新しました"
+#       redirect_to share_path(@share.id)
+#     else
+#       render 'edit'
+#     end
+#   end
+
+#   def destroy
+#     @share = Share.find(params[:id])
+#     # アクセス権
+#     @correct_user = User.find(@share.goal.user_id)
+#     if @correct_user.id != current_user.id
+#       redirect_to goals_path
+#     end
+#     @share.destroy
+#     flash[:notice] = "削除しました"
+#     redirect_to shares_path
+#   end
+
+#   private
+
+#   def share_params
+#     params.require(:share).permit(:category_id, :content)
+#   end
+# end

--- a/app/views/shares/old_index.html.erb
+++ b/app/views/shares/old_index.html.erb
@@ -1,0 +1,33 @@
+<!--サブエリア-->
+<div class="sub_area">
+  <%= render 'users/show', user: @user, clips: @clips %>
+</div>
+
+<!--メインエリア-->
+<div class="main_area">
+  <!--ページヘッド部-->
+  <div class="row mt-4">
+    <div class="col-12">
+      <%= form_with(url: shares_path, method: :get, enforce_utf8: false,class:"d-flex align-items-center", local: true) do |f| %>
+        <%= f.collection_select :search_category, Category.all, :id, :name, :include_blank => "カテゴリを選択",:selected => @category,id:"search_category" %>
+        <%= f.check_box :search_status,class:"ml-4 form-check-inline",id:"search_status" %>
+        <%= f.label :達成済みのみ表示, for:"search_status" %>
+        <%= f.check_box :search_sort,class:"ml-4 form-check-inline",id:"search_sort" %>
+        <%= f.label :クリップが多い順, for:"search_sort" %>
+        <%= f.text_field :search_word,class:"ml-4 form-control-sm",value: @word,id:"search_word" %>
+        <%= f.button :type => "submit", class:"btn" do %>
+          <i class="fas fa-search search_form_icon"></i>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+  <div class="row mt-3">
+    <div class="share_area">
+      <div class="share_area_inside">
+        <div class="col-12 d-flex flex-wrap align-content-around built_target">
+          <!--<div class=""></div>-->
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shares/old_index.json.jbuilder
+++ b/app/views/shares/old_index.json.jbuilder
@@ -1,0 +1,11 @@
+if @shares
+  json.array! @shares do |share|
+    json.id share.id
+    json.comp share.goal.status
+    json.user share.user
+    json.name share.user.name
+    json.content share.goal.content
+    json.category share.category.name
+    json.clips share.clips.count
+  end
+end


### PR DESCRIPTION
#37 
シェア検索画面にて、チェックを入れた項目の即時更新を行うためにjbuilderを使う提案をいただき実装したが、refileの画像データを扱えなかったため今回は見送り。
見送ったため未修正の「チェックを入れた回数表示件数が重複する」バグはあるが、今後の参考になるため記述は残しておく。
（関連ファイル：js,controller,html,jbuilder(すべて頭にold_がついているもの)