### PR TITLE
【バグ修正】今週の満足度

### DIFF
--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -33,10 +33,19 @@ class Goal < ApplicationRecord
     fulness = Report.where(goal_id: self.id).sum(:fulness)
     weekly = fulness / day
     # 1週間の中で月をまたぐ場合は月初から今日までを表示する
-    if monthly > weekly
-      return monthly
+    if monthly > 0
+      if monthly > weekly
+        return monthly
+      else
+        return weekly
+      end
     else
-      return weekly
+    # 月初がマイナスの場合
+      if monthly < weekly
+        return monthly
+      else
+        return weekly
+      end
     end
   end
 

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -24,28 +24,16 @@ class Goal < ApplicationRecord
     monthly = fulness / day
     return monthly
   end
-  def week_fulness
-    day = Time.now.day
-    fulness = Report.where(goal_id: self.id).sum(:fulness)
-    monthly = fulness / day
 
-    day = Time.now.wday
+  def week_fulness
     fulness = Report.where(goal_id: self.id).sum(:fulness)
-    weekly = fulness / day
+    day = Time.now.day
+    wday = Time.now.wday
     # 1週間の中で月をまたぐ場合は月初から今日までを表示する
-    if monthly > 0
-      if monthly > weekly
-        return monthly
-      else
-        return weekly
-      end
+    if wday > day
+      return monthly = fulness / day
     else
-    # 月初がマイナスの場合
-      if monthly < weekly
-        return monthly
-      else
-        return weekly
-      end
+      return weekly = fulness / wday
     end
   end
 


### PR DESCRIPTION
#44 
月初からの日数と、週初めからの日数を比較し、週初めからの日数の方が多い場合は月またぎであるため、
週の満足度においても月の満足度と同じものを表示する